### PR TITLE
Split FFunctor/FMonad instances using hs-boot

### DIFF
--- a/functor-monad/functor-monad.cabal
+++ b/functor-monad/functor-monad.cabal
@@ -10,27 +10,41 @@ extra-doc-files:     CHANGELOG.md, README.md
 
 library
   hs-source-dirs:  src
-  exposed-modules: FFunctor, FFunctor.FCompose,
-                   FFunctor.Adjunction,
-                   FMonad, FMonad.FreeT,
-                   FMonad.State.Day,
-                   FMonad.State.Ran,
-                   FMonad.State.Lan,
-                   FMonad.State.Simple.Inner,
-                   FMonad.State.Simple.Outer,
-                   FMonad.FFree, FMonad.Adjoint,
-                   FStrong,
-                   FComonad, FComonad.Adjoint,
 
-                   Control.Monad.Trail,
-                   
-                   Control.Monad.Trans.Free.Extra,
-                   Data.Functor.Precompose,
-                   Data.Functor.Bicompose,
-                   Data.Functor.Flip1,
-                   Data.Functor.Day.Comonoid,
-                   Data.Functor.Day.Extra,
-                   Data.Bifunctor.Product.Extra
+  exposed-modules:
+    FFunctor,
+    FFunctor.FCompose,
+    FFunctor.Adjunction,
+
+    FMonad,
+    FMonad.FreeT,
+    FMonad.State.Day,
+    FMonad.State.Ran,
+    FMonad.State.Lan,
+    FMonad.State.Simple.Inner,
+    FMonad.State.Simple.Outer,
+    FMonad.FFree, FMonad.Adjoint,
+    FStrong,
+    FComonad, FComonad.Adjoint,
+
+    Control.Monad.Trail,
+    
+    Control.Monad.Trans.Free.Extra,
+    Data.Functor.Precompose,
+    Data.Functor.Bicompose,
+    Data.Functor.Flip1,
+    Data.Functor.Day.Comonoid,
+    Data.Functor.Day.Extra,
+    Data.Bifunctor.Product.Extra
+  other-modules: 
+    FFunctor.Instances.Day,
+    FFunctor.Instances.Kan,
+    FFunctor.Instances.Free,
+    FFunctor.Instances.Trans,
+    FMonad.Instances.Day,
+    FMonad.Instances.Kan,
+    FMonad.Instances.Free,
+    FMonad.Instances.Trans,
   build-depends:       base >= 4.10 && < 5
                      , transformers
                      , comonad

--- a/functor-monad/functor-monad.cabal
+++ b/functor-monad/functor-monad.cabal
@@ -34,8 +34,7 @@ library
     Data.Functor.Bicompose,
     Data.Functor.Flip1,
     Data.Functor.Day.Comonoid,
-    Data.Functor.Day.Extra,
-    Data.Bifunctor.Product.Extra
+    Data.Functor.Day.Extra
   other-modules: 
     FFunctor.Instances.Day,
     FFunctor.Instances.Kan,
@@ -45,6 +44,7 @@ library
     FMonad.Instances.Kan,
     FMonad.Instances.Free,
     FMonad.Instances.Trans,
+    Data.Bifunctor.Product.Extra
   build-depends:       base >= 4.10 && < 5
                      , transformers
                      , comonad

--- a/functor-monad/src/Data/Functor/Bicompose.hs
+++ b/functor-monad/src/Data/Functor/Bicompose.hs
@@ -10,15 +10,11 @@
 module Data.Functor.Bicompose where
 
 import Control.Applicative (Alternative)
-import Control.Monad (join)
 import Data.Functor.Classes (Eq1, Ord1)
 import Data.Functor.Compose
 import Data.Kind (Type)
-import FMonad
-import FComonad
 
 import Data.Functor.Precompose (type (:.:))
-import Control.Comonad
 
 -- | Both-side composition of Monad.
 --
@@ -50,14 +46,3 @@ deriving via
   (f :.: h :.: g)
   instance
     (Alternative f, Applicative g, Applicative h) => Alternative (Bicompose f g h)
-
-instance (Functor f, Functor g) => FFunctor (Bicompose f g) where
-  ffmap gh = Bicompose . fmap gh . getBicompose
-
-instance (Monad f, Monad g) => FMonad (Bicompose f g) where
-  fpure = Bicompose . return . fmap return
-  fbind k = Bicompose . fmap (fmap join) . (getBicompose . k =<<) . getBicompose
-
-instance (Comonad f, Comonad g) => FComonad (Bicompose f g) where
-  fextract = fmap extract . extract . getBicompose
-  fextend tr = Bicompose . extend (tr . Bicompose) . fmap (fmap duplicate) . getBicompose

--- a/functor-monad/src/Data/Functor/Precompose.hs
+++ b/functor-monad/src/Data/Functor/Precompose.hs
@@ -13,13 +13,8 @@ module Data.Functor.Precompose where
 import Data.Kind (Type)
 
 import Control.Applicative (Alternative)
-import Control.Monad (join)
-import Control.Comonad(Comonad(..))
 import Data.Functor.Classes (Eq1, Ord1)
 import Data.Functor.Compose ( Compose(..) )
-
-import FMonad
-import FComonad
 
 -- | Single-kinded type alias of Compose
 type (:.:) :: (Type -> Type) -> (Type -> Type) -> Type -> Type
@@ -66,14 +61,3 @@ deriving via
   (g :.: f)
   instance
     (Applicative f, Alternative g) => Alternative (Precompose f g)
-
-instance Functor f => FFunctor (Precompose f) where
-  ffmap gh = Precompose . gh . getPrecompose
-
-instance Monad f => FMonad (Precompose f) where
-  fpure = Precompose . fmap return
-  fbind k = Precompose . fmap join . getPrecompose . k . getPrecompose
-
-instance Comonad f => FComonad (Precompose f) where
-  fextract = fmap extract . getPrecompose
-  fextend tr = Precompose . tr . Precompose . fmap duplicate . getPrecompose

--- a/functor-monad/src/FComonad.hs
+++ b/functor-monad/src/FComonad.hs
@@ -27,6 +27,8 @@ import qualified Control.Comonad.Cofree as Cofree
 
 import FFunctor
 import Data.Coerce (coerce)
+import Data.Functor.Precompose
+import Data.Functor.Bicompose
 
 class FFunctor ff => FComonad ff where
     fextract :: Functor g => ff g ~> g
@@ -46,6 +48,14 @@ instance Functor f => FComonad (Product f) where
 instance Comonad f => FComonad (Compose f) where
     fextract = extract . getCompose
     fextend tr = Compose . extend (tr . Compose) . getCompose
+
+instance Comonad f => FComonad (Precompose f) where
+  fextract = fmap extract . getPrecompose
+  fextend tr = Precompose . tr . Precompose . fmap duplicate . getPrecompose
+
+instance (Comonad f, Comonad g) => FComonad (Bicompose f g) where
+  fextract = fmap extract . extract . getBicompose
+  fextend tr = Bicompose . extend (tr . Bicompose) . fmap (fmap duplicate) . getBicompose
 
 instance (FComonad ff, FComonad gg) => FComonad (Bi.Sum ff gg) where
     fextract (Bi.L2 ffx) = fextract ffx

--- a/functor-monad/src/FFunctor.hs
+++ b/functor-monad/src/FFunctor.hs
@@ -27,6 +27,8 @@ import FFunctor.Instances.Day()
 import FFunctor.Instances.Kan()
 import FFunctor.Instances.Trans()
 import FFunctor.Instances.Free()
+import Data.Functor.Precompose
+import Data.Functor.Bicompose
 
 -- | Natural transformation arrow
 type (~>) :: (k -> Type) -> (k -> Type) -> Type
@@ -95,3 +97,9 @@ instance (FFunctor ff, FFunctor gg) => FFunctor (Bi.Sum ff gg) where
 
 instance (FFunctor ff, FFunctor gg) => FFunctor (Bi.Product ff gg) where
   ffmap t (Bi.Pair ff gg) = Bi.Pair (ffmap t ff) (ffmap t gg)
+
+instance Functor f => FFunctor (Precompose f) where
+  ffmap gh = Precompose . gh . getPrecompose
+
+instance (Functor f, Functor g) => FFunctor (Bicompose f g) where
+  ffmap gh = Bicompose . fmap gh . getBicompose

--- a/functor-monad/src/FFunctor.hs
+++ b/functor-monad/src/FFunctor.hs
@@ -15,22 +15,7 @@ module FFunctor
   )
 where
 
-import qualified Control.Applicative.Free as FreeAp
-import qualified Control.Applicative.Free.Final as FreeApFinal
-import Control.Applicative.Lift
-import qualified Control.Applicative.Trans.FreeAp as FreeApT
-import qualified Control.Monad.Free as FreeM
-import qualified Control.Monad.Free.Church as FreeMChurch
-import Control.Monad.Trans.Identity
-import Control.Monad.Trans.Reader
-import Control.Monad.Trans.State
-import Control.Monad.Trans.Writer
 import Data.Functor.Compose
-import Data.Functor.Day
-import Data.Functor.Day.Curried
-import Data.Functor.Flip1
-import Data.Functor.Kan.Lan
-import Data.Functor.Kan.Ran
 import Data.Functor.Product
 import Data.Functor.Sum
 import Data.Kind (Constraint, Type)
@@ -38,10 +23,10 @@ import Data.Kind (Constraint, Type)
 import qualified Data.Bifunctor.Sum as Bi
 import qualified Data.Bifunctor.Product as Bi
 
-import Control.Comonad.Env (EnvT(..))
-import Control.Comonad.Traced (TracedT(..))
-import Control.Comonad.Store (StoreT (..))
-import Control.Comonad.Cofree (Cofree, hoistCofree)
+import FFunctor.Instances.Day()
+import FFunctor.Instances.Kan()
+import FFunctor.Instances.Trans()
+import FFunctor.Instances.Free()
 
 -- | Natural transformation arrow
 type (~>) :: (k -> Type) -> (k -> Type) -> Type
@@ -104,66 +89,9 @@ instance Functor f => FFunctor (Product f) where
 instance Functor f => FFunctor (Compose f) where
   ffmap gh = Compose . fmap gh . getCompose
 
-instance FFunctor Lift where
-  ffmap gh = mapLift gh
-
-instance FFunctor FreeM.Free where
-  ffmap = FreeM.hoistFree
-
-instance FFunctor FreeMChurch.F where
-  ffmap = FreeMChurch.hoistF
-
-instance FFunctor FreeAp.Ap where
-  ffmap = FreeAp.hoistAp
-
-instance FFunctor FreeApFinal.Ap where
-  ffmap = FreeApFinal.hoistAp
-
-instance FFunctor IdentityT where
-  ffmap fg = IdentityT . fg . runIdentityT
-
-instance FFunctor (ReaderT e) where
-  ffmap fg = ReaderT . fmap fg . runReaderT
-
-instance FFunctor (WriterT m) where
-  ffmap fg = WriterT . fg . runWriterT
-
-instance FFunctor (StateT s) where
-  ffmap fg = StateT . fmap fg . runStateT
-
-instance FFunctor (Ran f) where
-  ffmap gh (Ran ran) = Ran (gh . ran)
-
-instance FFunctor (Lan f) where
-  ffmap gh (Lan e g) = Lan e (gh g)
-
-instance FFunctor (Day f) where
-  ffmap = trans2
-
-instance Functor f => FFunctor (Curried f) where
-  ffmap gh (Curried t) = Curried (gh . t)
-
-instance FFunctor (FreeApT.ApT f) where
-  ffmap = FreeApT.hoistApT
-
-instance Functor g => FFunctor (Flip1 FreeApT.ApT g) where
-  ffmap f2g = Flip1 . FreeApT.transApT f2g . unFlip1
-
 instance (FFunctor ff, FFunctor gg) => FFunctor (Bi.Sum ff gg) where
   ffmap t (Bi.L2 ff) = Bi.L2 (ffmap t ff)
   ffmap t (Bi.R2 gg) = Bi.R2 (ffmap t gg)
 
 instance (FFunctor ff, FFunctor gg) => FFunctor (Bi.Product ff gg) where
   ffmap t (Bi.Pair ff gg) = Bi.Pair (ffmap t ff) (ffmap t gg)
-
-instance FFunctor (EnvT e) where
-  ffmap gh (EnvT e g) = EnvT e (gh g)
-
-instance FFunctor (TracedT m) where
-  ffmap gh (TracedT g) = TracedT (gh g)
-
-instance FFunctor (StoreT s) where
-  ffmap gh (StoreT g s) = StoreT (gh g) s
-
-instance FFunctor Cofree where
-  ffmap = hoistCofree

--- a/functor-monad/src/FFunctor.hs-boot
+++ b/functor-monad/src/FFunctor.hs-boot
@@ -1,0 +1,40 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE QuantifiedConstraints #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE StandaloneKindSignatures #-}
+{-# LANGUAGE TypeOperators #-}
+
+module FFunctor
+  ( type (~>),
+    FUNCTOR,
+    FF,
+    FFunctor (..),
+  )
+where
+
+import Data.Kind
+
+import Data.Functor.Compose ( Compose )
+import Data.Functor.Product ( Product )
+import Data.Functor.Sum ( Sum )
+
+-- | Natural transformation arrow
+type (~>) :: (k -> Type) -> (k -> Type) -> Type
+type (~>) f g = forall x. f x -> g x
+
+-- | The kind of a @Functor@
+type FUNCTOR = Type -> Type
+
+-- | The kind of a @FFunctor@.
+type FF = FUNCTOR -> FUNCTOR
+
+type FFunctor :: FF -> Constraint
+class (forall g. Functor g => Functor (ff g)) => FFunctor ff where
+  ffmap :: (Functor g, Functor h) => (g ~> h) -> (ff g x -> ff h x)
+
+instance Functor f => FFunctor (Sum f)
+instance Functor f => FFunctor (Product f)
+instance Functor f => FFunctor (Compose f)

--- a/functor-monad/src/FFunctor.hs-boot
+++ b/functor-monad/src/FFunctor.hs-boot
@@ -21,6 +21,9 @@ import Data.Functor.Compose ( Compose )
 import Data.Functor.Product ( Product )
 import Data.Functor.Sum ( Sum )
 
+import Data.Functor.Precompose (Precompose)
+import Data.Functor.Bicompose (Bicompose)
+
 -- | Natural transformation arrow
 type (~>) :: (k -> Type) -> (k -> Type) -> Type
 type (~>) f g = forall x. f x -> g x
@@ -38,3 +41,5 @@ class (forall g. Functor g => Functor (ff g)) => FFunctor ff where
 instance Functor f => FFunctor (Sum f)
 instance Functor f => FFunctor (Product f)
 instance Functor f => FFunctor (Compose f)
+instance Functor f => FFunctor (Precompose f)
+instance (Functor f, Functor g) => FFunctor (Bicompose f g)

--- a/functor-monad/src/FFunctor/Instances/Day.hs
+++ b/functor-monad/src/FFunctor/Instances/Day.hs
@@ -1,0 +1,15 @@
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ExistentialQuantification #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+module FFunctor.Instances.Day where
+
+import {-# SOURCE #-} FFunctor
+
+import Data.Functor.Day
+import Data.Functor.Day.Curried
+
+instance FFunctor (Day f) where
+  ffmap = trans2
+
+instance Functor f => FFunctor (Curried f) where
+  ffmap gh (Curried t) = Curried (gh . t)

--- a/functor-monad/src/FFunctor/Instances/Free.hs
+++ b/functor-monad/src/FFunctor/Instances/Free.hs
@@ -1,0 +1,36 @@
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+module FFunctor.Instances.Free where
+
+import {-# SOURCE #-} FFunctor
+
+import qualified Control.Applicative.Free as FreeAp
+import qualified Control.Applicative.Free.Final as FreeApFinal
+import qualified Control.Applicative.Trans.FreeAp as FreeApT
+import qualified Control.Monad.Free as FreeM
+import qualified Control.Monad.Free.Church as FreeMChurch
+
+import Control.Comonad.Cofree (Cofree, hoistCofree)
+import Data.Functor.Flip1
+
+instance FFunctor FreeM.Free where
+  ffmap = FreeM.hoistFree
+
+instance FFunctor FreeMChurch.F where
+  ffmap = FreeMChurch.hoistF
+
+instance FFunctor FreeAp.Ap where
+  ffmap = FreeAp.hoistAp
+
+instance FFunctor FreeApFinal.Ap where
+  ffmap = FreeApFinal.hoistAp
+
+instance FFunctor (FreeApT.ApT f) where
+  ffmap = FreeApT.hoistApT
+
+instance Functor g => FFunctor (Flip1 FreeApT.ApT g) where
+  ffmap f2g = Flip1 . FreeApT.transApT f2g . unFlip1
+
+instance FFunctor Cofree where
+  ffmap = hoistCofree

--- a/functor-monad/src/FFunctor/Instances/Kan.hs
+++ b/functor-monad/src/FFunctor/Instances/Kan.hs
@@ -1,0 +1,15 @@
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ExistentialQuantification #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+module FFunctor.Instances.Kan where
+
+import {-# SOURCE #-} FFunctor
+
+import Data.Functor.Kan.Lan
+import Data.Functor.Kan.Ran
+
+instance FFunctor (Ran f) where
+  ffmap gh (Ran ran) = Ran (gh . ran)
+
+instance FFunctor (Lan f) where
+  ffmap gh (Lan e g) = Lan e (gh g)

--- a/functor-monad/src/FFunctor/Instances/Trans.hs
+++ b/functor-monad/src/FFunctor/Instances/Trans.hs
@@ -1,0 +1,39 @@
+{-# LANGUAGE RankNTypes #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+module FFunctor.Instances.Trans where
+
+import {-# SOURCE #-} FFunctor
+
+import Control.Applicative.Lift
+import Control.Monad.Trans.Identity
+import Control.Monad.Trans.Reader
+import Control.Monad.Trans.State
+import Control.Monad.Trans.Writer
+
+import Control.Comonad.Env (EnvT(..))
+import Control.Comonad.Traced (TracedT(..))
+import Control.Comonad.Store (StoreT (..))
+
+instance FFunctor Lift where
+  ffmap gh = mapLift gh
+
+instance FFunctor IdentityT where
+  ffmap fg = IdentityT . fg . runIdentityT
+
+instance FFunctor (ReaderT e) where
+  ffmap fg = ReaderT . fmap fg . runReaderT
+
+instance FFunctor (WriterT m) where
+  ffmap fg = WriterT . fg . runWriterT
+
+instance FFunctor (StateT s) where
+  ffmap fg = StateT . fmap fg . runStateT
+
+instance FFunctor (EnvT e) where
+  ffmap gh (EnvT e g) = EnvT e (gh g)
+
+instance FFunctor (TracedT m) where
+  ffmap gh (TracedT g) = TracedT (gh g)
+
+instance FFunctor (StoreT s) where
+  ffmap gh (StoreT g s) = StoreT (gh g) s

--- a/functor-monad/src/FMonad.hs
+++ b/functor-monad/src/FMonad.hs
@@ -18,32 +18,19 @@ module FMonad
   )
 where
 
-import qualified Control.Applicative.Free as FreeAp
-import qualified Control.Applicative.Free.Final as FreeApFinal
-import Control.Applicative.Lift
-import qualified Control.Applicative.Trans.FreeAp as FreeApT
-import Control.Comonad (Comonad (..), (=>=))
-import Control.Monad (join)
-import qualified Control.Monad.Free as FreeM
-import qualified Control.Monad.Free.Church as FreeMChurch
-import Control.Monad.Trans.Identity
-import Control.Monad.Trans.Reader
-import Control.Monad.Trans.State
-import Control.Monad.Trans.Writer
 import Data.Functor.Compose
-import Data.Functor.Day
-import Data.Functor.Day.Comonoid
-import Data.Functor.Day.Curried
-import Data.Functor.Day.Extra (uncurried)
-import Data.Functor.Flip1
-import Data.Functor.Kan.Lan
-import Data.Functor.Kan.Ran
 import Data.Functor.Product
 import Data.Functor.Sum
-import FFunctor
 
 import qualified Data.Bifunctor.Product as Bi
 import qualified Data.Bifunctor.Product.Extra as Bi
+
+import FFunctor
+
+import FMonad.Instances.Day()
+import FMonad.Instances.Kan()
+import FMonad.Instances.Trans()
+import FMonad.Instances.Free()
 
 -- | Monad on 'Functor's.
 --
@@ -93,206 +80,6 @@ instance (Functor f, forall a. Monoid (f a)) => FMonad (Product f) where
 instance Monad f => FMonad (Compose f) where
   fpure = Compose . return
   fbind k = Compose . (>>= (getCompose . k)) . getCompose
-
-instance FMonad Lift where
-  fpure = Other
-  fbind _ (Pure a)   = Pure a
-  fbind k (Other ga) = k ga
-
-instance FMonad FreeM.Free where
-  fpure = FreeM.liftF
-  fbind = FreeM.foldFree
-
-instance FMonad FreeMChurch.F where
-  fpure = FreeMChurch.liftF
-  fbind = FreeMChurch.foldF
-
-instance FMonad FreeAp.Ap where
-  fpure = FreeAp.liftAp
-  fbind = FreeAp.runAp
-
-instance FMonad FreeApFinal.Ap where
-  fpure = FreeApFinal.liftAp
-  fbind = FreeApFinal.runAp
-
-instance FMonad IdentityT where
-  fpure = IdentityT
-  fbind k = k . runIdentityT
-
-instance FMonad (ReaderT e) where
-  -- See the similarity between 'Compose' @((->) e)@
-
-  -- return :: x -> (e -> x)
-  fpure = ReaderT . return
-
-  -- join :: (e -> e -> x) -> (e -> x)
-  fbind k = ReaderT . (>>= runReaderT . k) . runReaderT
-
-instance Monoid m => FMonad (WriterT m) where
-  -- See the similarity between 'FlipCompose' @(Writer m)@
-
-  -- fmap return :: f x -> f (Writer m x)
-  fpure = WriterT . fmap (,mempty)
-
-  -- fmap join :: f (Writer m (Writer m x)) -> f (Writer m x)
-  fbind k = WriterT . fmap (\((x, m1), m2) -> (x, m2 <> m1)) . runWriterT . runWriterT . ffmap k
-
-{-
-
-If everything is unwrapped, FMonad @(StateT s)@ is
-
-  fpure :: forall f. Functor f => f x -> s -> f (x, s)
-  fjoin :: forall f. Functor f => (s -> s -> f ((x, s), s)) -> s -> f (x, s)
-
-And if this type was generic in @s@ without any constraint like @Monoid s@,
-the only possible implementations are
-
-  -- fpure is uniquely:
-  fpure fx s = (,s) <$> fx
-
-  -- fjoin is one of the following three candidates
-  fjoin1 stst s = (\((x,_),_) -> (x,s)) <$> stst s s
-  fjoin2 stst s = (\((x,_),s) -> (x,s)) <$> stst s s
-  fjoin3 stst s = (\((x,s),_) -> (x,s)) <$> stst s s
-
-But none of them satisfy the FMonad law.
-
-  (fjoin1 . fpure) st
-    = fjoin1 $ \s1 s2 -> (,s1) <$> st s2
-    = \s -> (\((x,_),_) -> (x,s)) <$> ((,s) <$> st s)
-    = \s -> (\(x,_) -> (x,s)) <$> st s
-    /= st
-  (fjoin2 . fpure) st
-    = fjoin2 $ \s1 s2 -> (,s1) <$> st s2
-    = \s -> (\((x,_),s') -> (x,s')) <$> ((,s) <$> st s)
-    = \s -> (\(x,_) -> (x,s)) <$> st s
-    /= st
-  (fjoin3 . ffmap fpure) st
-    = fjoin2 $ \s1 s2 -> fmap (fmap (,s2)) . st s1
-    = \s -> ((\((x,s'),_) -> (x,s')) . fmap (,s)) <$> st s
-    = \s -> (\(x,_) -> (x,s)) <$> st s
-    /= st
-
-So the lawful @FMonad (StateT s)@ will utilize some structure
-on @s@.
-
-One way would be seeing StateT as the composision of Reader s and
-Writer s:
-
-  StateT s m ~ Reader s ∘ m ∘ Writer s
-    where (∘) = Compose
-
-By this way
-
-  StateT s (StateT s m) ~ Reader s ∘ Reader s ∘ m ∘ Writer s ∘ Writer s
-
-And you can collapse the nesting by applying @join@ for @Reader s ∘ Reader s@
-and @Writer s ∘ Writer s@. To do so, it will need @Monoid s@ for @Monad (Writer s)@.
-
--}
-
-instance Monoid s => FMonad (StateT s) where
-  -- Note that this is different to @lift@ in 'MonadTrans',
-  -- whilst having similar type and actually equal in
-  -- several other 'FMonad' instances.
-  --
-  -- See the discussion below.
-  fpure fa = StateT $ \_ -> (,mempty) <$> fa
-
-  fbind k = StateT . fjoin_ . fmap runStateT . runStateT . ffmap k
-    where
-      fjoin_ :: forall f a. (Functor f) => (s -> s -> f ((a, s), s)) -> s -> f (a, s)
-      fjoin_ = fmap (fmap joinWriter) . joinReader
-        where
-          joinReader :: forall x. (s -> s -> x) -> s -> x
-          joinReader = join
-
-          joinWriter :: forall x. ((x, s), s) -> (x, s)
-          joinWriter ((a, s1), s2) = (a, s2 <> s1)
-
-{-
-
-Note [About FMonad (StateT s) instance]
-
-@fpure@ has a similar (Functor instead of Monad) type signature
-with 'lift', but due to the different laws expected on them,
-they aren't necessarily same.
-
-@lift@ for @StateT s@ must be, by the 'MonadTrans' laws,
-the one currently used. And this is not because the parameter @s@
-is generic, so it applies if we have @Monoid s =>@ constraints like
-the above instance.
-
-One way to have @lift = fpure@ here is requiring @s@ to be a type with
-group operations, @Monoid@ + @inv@ for inverse operator,
-instead of just being a monoid.
-
-> fpure fa = StateT $ \s -> (,s) <$> fa
-> fjoin = StateT . fjoin_ . fmap runStateT . runStateT
->   where fjoin_ mma s = fmap (fmap (joinGroup s)) $ joinReader mma s
->         joinReader = join
->         joinGroup s ((x,s1),s2) = (x, s2 <> inv s <> s1)
-
--}
-
--- | @Ran w (Ran w f) ~ Ran ('Compose' w w) f@
-instance (Comonad w) => FMonad (Ran w) where
-  fpure ::
-    forall f x.
-    (Functor f) =>
-    f x ->
-    Ran w f x
-  --       f x -> (forall b. (x -> w b) -> f b)
-  fpure f = Ran $ \k -> fmap (extract . k) f
-
-  fbind :: (Functor g, Functor h) =>
-     (g ~> Ran w h) -> (Ran w g ~> Ran w h)
-  fbind k wg = Ran $ \xd -> runRan (k (runRan wg (duplicate . xd))) id
-
--- | @Lan w (Lan w f) ~ Lan ('Compose' w w) f@
-instance (Comonad w) => FMonad (Lan w) where
-  fpure ::
-    forall f x.
-    (Functor f) =>
-    f x ->
-    Lan w f x
-  --       f x -> exists b. (w b -> x, f b)
-  fpure f = Lan extract f
-  
-  fbind :: (Functor g, Functor h) =>
-    (g ~> Lan w h) -> (Lan w g ~> Lan w h)
-  fbind k (Lan j1 g) = case k g of
-    Lan j2 h -> Lan (j2 =>= j1) h
-
-instance (Applicative f) => FMonad (Day f) where
-  fpure :: g ~> Day f g
-  fpure = day (pure id)
-
-  {-
-     day :: f (a -> b) -> g a -> Day f g b
-  -}
-  
-  fbind k = trans1 dap . assoc . trans2 k
-
-{-
-   trans2 k   :: Day f g ~> Day f (Day f h)
-   assoc      ::            Day f (Day f h) ~> Day (Day f f) h
-   trans1 dap ::                               Day (Day f f) h ~> Day f h
--}
-
-instance Comonoid f => FMonad (Curried f) where
-  fpure :: Functor g => g a -> Curried f g a
-  fpure g = Curried $ \f -> extract f <$> g
-
-  fbind k m = Curried $ \f -> runCurried (uncurried (ffmap k m)) (coapply f)
-
-instance FMonad (FreeApT.ApT f) where
-  fpure = FreeApT.liftT
-  fbind k = FreeApT.fjoinApTLeft . ffmap k
-
-instance Applicative g => FMonad (Flip1 FreeApT.ApT g) where
-  fpure = Flip1 . FreeApT.liftF
-  fbind k = Flip1 . FreeApT.foldApT (unFlip1 . k) FreeApT.liftT . unFlip1
 
 instance (FMonad ff, FMonad gg) => FMonad (Bi.Product ff gg) where
   fpure h = Bi.Pair (fpure h) (fpure h)

--- a/functor-monad/src/FMonad.hs
+++ b/functor-monad/src/FMonad.hs
@@ -18,6 +18,7 @@ module FMonad
   )
 where
 
+import Control.Monad (join)
 import Data.Functor.Compose
 import Data.Functor.Product
 import Data.Functor.Sum
@@ -26,6 +27,9 @@ import qualified Data.Bifunctor.Product as Bi
 import qualified Data.Bifunctor.Product.Extra as Bi
 
 import FFunctor
+
+import Data.Functor.Precompose
+import Data.Functor.Bicompose
 
 import FMonad.Instances.Day()
 import FMonad.Instances.Kan()
@@ -84,3 +88,11 @@ instance Monad f => FMonad (Compose f) where
 instance (FMonad ff, FMonad gg) => FMonad (Bi.Product ff gg) where
   fpure h = Bi.Pair (fpure h) (fpure h)
   fbind k (Bi.Pair ff gg) = Bi.Pair (fbind (Bi.proj1 . k) ff) (fbind (Bi.proj2 . k) gg)
+
+instance Monad f => FMonad (Precompose f) where
+  fpure = Precompose . fmap return
+  fbind k = Precompose . fmap join . getPrecompose . k . getPrecompose
+
+instance (Monad f, Monad g) => FMonad (Bicompose f g) where
+  fpure = Bicompose . return . fmap return
+  fbind k = Bicompose . fmap (fmap join) . (getBicompose . k =<<) . getBicompose

--- a/functor-monad/src/FMonad.hs-boot
+++ b/functor-monad/src/FMonad.hs-boot
@@ -15,6 +15,8 @@ import {-# SOURCE #-} FFunctor
 import Data.Functor.Compose ( Compose )
 import Data.Functor.Product ( Product )
 import Data.Functor.Sum ( Sum )
+import Data.Functor.Precompose (Precompose)
+import Data.Functor.Bicompose (Bicompose)
 
 class FFunctor ff => FMonad ff where
   fpure :: (Functor g) => g ~> ff g
@@ -25,3 +27,5 @@ fjoin :: (FMonad ff, Functor g) => ff (ff g) ~> ff g
 instance Functor f => FMonad (Sum f)
 instance (Functor f, forall a. Monoid (f a)) => FMonad (Product f)
 instance Monad f => FMonad (Compose f)
+instance Monad f => FMonad (Precompose f)
+instance (Monad f, Monad g) => FMonad (Bicompose f g)

--- a/functor-monad/src/FMonad.hs-boot
+++ b/functor-monad/src/FMonad.hs-boot
@@ -1,0 +1,27 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE QuantifiedConstraints #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TypeOperators #-}
+module FMonad
+  ( type (~>),
+    FFunctor (..),
+    FMonad (..),
+    fjoin
+  )
+where
+
+import {-# SOURCE #-} FFunctor
+
+import Data.Functor.Compose ( Compose )
+import Data.Functor.Product ( Product )
+import Data.Functor.Sum ( Sum )
+
+class FFunctor ff => FMonad ff where
+  fpure :: (Functor g) => g ~> ff g
+  fbind :: (Functor g, Functor h) => (g ~> ff h) -> ff g a -> ff h a
+
+fjoin :: (FMonad ff, Functor g) => ff (ff g) ~> ff g
+
+instance Functor f => FMonad (Sum f)
+instance (Functor f, forall a. Monoid (f a)) => FMonad (Product f)
+instance Monad f => FMonad (Compose f)

--- a/functor-monad/src/FMonad/Instances/Day.hs
+++ b/functor-monad/src/FMonad/Instances/Day.hs
@@ -1,0 +1,35 @@
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE InstanceSigs #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+module FMonad.Instances.Day where
+
+import {-# SOURCE #-} FMonad
+import FFunctor.Instances.Day()
+
+import Data.Functor.Day
+import Data.Functor.Day.Comonoid
+import Data.Functor.Day.Curried
+import Data.Functor.Day.Extra (uncurried)
+
+instance (Applicative f) => FMonad (Day f) where
+  fpure :: g ~> Day f g
+  fpure = day (pure id)
+
+  {-
+     day :: f (a -> b) -> g a -> Day f g b
+  -}
+  
+  fbind k = trans1 dap . assoc . trans2 k
+
+  {-
+    trans2 k   :: Day f g ~> Day f (Day f h)
+    assoc      ::            Day f (Day f h) ~> Day (Day f f) h
+    trans1 dap ::                               Day (Day f f) h ~> Day f h
+  -}
+
+instance Comonoid f => FMonad (Curried f) where
+  fpure :: Functor g => g a -> Curried f g a
+  fpure g = Curried $ \f -> extract f <$> g
+
+  fbind k m = Curried $ \f -> runCurried (uncurried (ffmap k m)) (coapply f)

--- a/functor-monad/src/FMonad/Instances/Free.hs
+++ b/functor-monad/src/FMonad/Instances/Free.hs
@@ -1,0 +1,39 @@
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+module FMonad.Instances.Free where
+
+import {-# SOURCE #-} FMonad
+import FFunctor.Instances.Free()
+
+import qualified Control.Applicative.Free as FreeAp
+import qualified Control.Applicative.Free.Final as FreeApFinal
+import qualified Control.Applicative.Trans.FreeAp as FreeApT
+import qualified Control.Monad.Free as FreeM
+import qualified Control.Monad.Free.Church as FreeMChurch
+
+import Data.Functor.Flip1
+
+instance FMonad FreeM.Free where
+  fpure = FreeM.liftF
+  fbind = FreeM.foldFree
+
+instance FMonad FreeMChurch.F where
+  fpure = FreeMChurch.liftF
+  fbind = FreeMChurch.foldF
+
+instance FMonad FreeAp.Ap where
+  fpure = FreeAp.liftAp
+  fbind = FreeAp.runAp
+
+instance FMonad FreeApFinal.Ap where
+  fpure = FreeApFinal.liftAp
+  fbind = FreeApFinal.runAp
+
+instance FMonad (FreeApT.ApT f) where
+  fpure = FreeApT.liftT
+  fbind k = FreeApT.fjoinApTLeft . ffmap k
+
+instance Applicative g => FMonad (Flip1 FreeApT.ApT g) where
+  fpure = Flip1 . FreeApT.liftF
+  fbind k = Flip1 . FreeApT.foldApT (unFlip1 . k) FreeApT.liftT . unFlip1

--- a/functor-monad/src/FMonad/Instances/Kan.hs
+++ b/functor-monad/src/FMonad/Instances/Kan.hs
@@ -1,0 +1,41 @@
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE InstanceSigs #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+module FMonad.Instances.Kan() where
+
+import Control.Comonad (Comonad (..), (=>=))
+import Data.Functor.Kan.Lan
+import Data.Functor.Kan.Ran
+
+import {-# SOURCE #-} FMonad
+import FFunctor.Instances.Kan()
+
+-- | @Ran w (Ran w f) ~ Ran ('Compose' w w) f@
+instance (Comonad w) => FMonad (Ran w) where
+  fpure ::
+    forall f x.
+    (Functor f) =>
+    f x ->
+    Ran w f x
+  --       f x -> (forall b. (x -> w b) -> f b)
+  fpure f = Ran $ \k -> fmap (extract . k) f
+
+  fbind :: (Functor g, Functor h) =>
+     (g ~> Ran w h) -> (Ran w g ~> Ran w h)
+  fbind k wg = Ran $ \xd -> runRan (k (runRan wg (duplicate . xd))) id
+
+-- | @Lan w (Lan w f) ~ Lan ('Compose' w w) f@
+instance (Comonad w) => FMonad (Lan w) where
+  fpure ::
+    forall f x.
+    (Functor f) =>
+    f x ->
+    Lan w f x
+  --       f x -> exists b. (w b -> x, f b)
+  fpure f = Lan extract f
+  
+  fbind :: (Functor g, Functor h) =>
+    (g ~> Lan w h) -> (Lan w g ~> Lan w h)
+  fbind k (Lan j1 g) = case k g of
+    Lan j2 h -> Lan (j2 =>= j1) h

--- a/functor-monad/src/FMonad/Instances/Trans.hs
+++ b/functor-monad/src/FMonad/Instances/Trans.hs
@@ -1,0 +1,140 @@
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+module FMonad.Instances.Trans where
+
+import {-# SOURCE #-} FMonad
+import FFunctor.Instances.Trans()
+
+import Control.Applicative.Lift
+import Control.Monad.Trans.Identity
+import Control.Monad.Trans.Reader
+import Control.Monad.Trans.State
+import Control.Monad.Trans.Writer
+import Control.Monad (join)
+
+instance FMonad Lift where
+  fpure = Other
+  fbind _ (Pure a)   = Pure a
+  fbind k (Other ga) = k ga
+
+instance FMonad IdentityT where
+  fpure = IdentityT
+  fbind k = k . runIdentityT
+
+instance FMonad (ReaderT e) where
+  -- See the similarity between 'Compose' @((->) e)@
+
+  -- return :: x -> (e -> x)
+  fpure = ReaderT . return
+
+  -- join :: (e -> e -> x) -> (e -> x)
+  fbind k = ReaderT . (>>= runReaderT . k) . runReaderT
+
+instance Monoid m => FMonad (WriterT m) where
+  -- See the similarity between 'FlipCompose' @(Writer m)@
+
+  -- fmap return :: f x -> f (Writer m x)
+  fpure = WriterT . fmap (,mempty)
+
+  -- fmap join :: f (Writer m (Writer m x)) -> f (Writer m x)
+  fbind k = WriterT . fmap (\((x, m1), m2) -> (x, m2 <> m1)) . runWriterT . runWriterT . ffmap k
+
+{-
+
+If everything is unwrapped, FMonad @(StateT s)@ is
+
+  fpure :: forall f. Functor f => f x -> s -> f (x, s)
+  fjoin :: forall f. Functor f => (s -> s -> f ((x, s), s)) -> s -> f (x, s)
+
+And if this type was generic in @s@ without any constraint like @Monoid s@,
+the only possible implementations are
+
+  -- fpure is uniquely:
+  fpure fx s = (,s) <$> fx
+
+  -- fjoin is one of the following three candidates
+  fjoin1 stst s = (\((x,_),_) -> (x,s)) <$> stst s s
+  fjoin2 stst s = (\((x,_),s) -> (x,s)) <$> stst s s
+  fjoin3 stst s = (\((x,s),_) -> (x,s)) <$> stst s s
+
+But none of them satisfy the FMonad law.
+
+  (fjoin1 . fpure) st
+    = fjoin1 $ \s1 s2 -> (,s1) <$> st s2
+    = \s -> (\((x,_),_) -> (x,s)) <$> ((,s) <$> st s)
+    = \s -> (\(x,_) -> (x,s)) <$> st s
+    /= st
+  (fjoin2 . fpure) st
+    = fjoin2 $ \s1 s2 -> (,s1) <$> st s2
+    = \s -> (\((x,_),s') -> (x,s')) <$> ((,s) <$> st s)
+    = \s -> (\(x,_) -> (x,s)) <$> st s
+    /= st
+  (fjoin3 . ffmap fpure) st
+    = fjoin2 $ \s1 s2 -> fmap (fmap (,s2)) . st s1
+    = \s -> ((\((x,s'),_) -> (x,s')) . fmap (,s)) <$> st s
+    = \s -> (\(x,_) -> (x,s)) <$> st s
+    /= st
+
+So the lawful @FMonad (StateT s)@ will utilize some structure
+on @s@.
+
+One way would be seeing StateT as the composision of Reader s and
+Writer s:
+
+  StateT s m ~ Reader s ∘ m ∘ Writer s
+    where (∘) = Compose
+
+By this way
+
+  StateT s (StateT s m) ~ Reader s ∘ Reader s ∘ m ∘ Writer s ∘ Writer s
+
+And you can collapse the nesting by applying @join@ for @Reader s ∘ Reader s@
+and @Writer s ∘ Writer s@. To do so, it will need @Monoid s@ for @Monad (Writer s)@.
+
+-}
+
+instance Monoid s => FMonad (StateT s) where
+  -- Note that this is different to @lift@ in 'MonadTrans',
+  -- whilst having similar type and actually equal in
+  -- several other 'FMonad' instances.
+  --
+  -- See the discussion below.
+  fpure fa = StateT $ \_ -> (,mempty) <$> fa
+
+  fbind k = StateT . fjoin_ . fmap runStateT . runStateT . ffmap k
+    where
+      fjoin_ :: forall f a. (Functor f) => (s -> s -> f ((a, s), s)) -> s -> f (a, s)
+      fjoin_ = fmap (fmap joinWriter) . joinReader
+        where
+          joinReader :: forall x. (s -> s -> x) -> s -> x
+          joinReader = join
+
+          joinWriter :: forall x. ((x, s), s) -> (x, s)
+          joinWriter ((a, s1), s2) = (a, s2 <> s1)
+
+{-
+
+Note [About FMonad (StateT s) instance]
+
+@fpure@ has a similar (Functor instead of Monad) type signature
+with 'lift', but due to the different laws expected on them,
+they aren't necessarily same.
+
+@lift@ for @StateT s@ must be, by the 'MonadTrans' laws,
+the one currently used. And this is not because the parameter @s@
+is generic, so it applies if we have @Monoid s =>@ constraints like
+the above instance.
+
+One way to have @lift = fpure@ here is requiring @s@ to be a type with
+group operations, @Monoid@ + @inv@ for inverse operator,
+instead of just being a monoid.
+
+> fpure fa = StateT $ \s -> (,s) <$> fa
+> fjoin = StateT . fjoin_ . fmap runStateT . runStateT
+>   where fjoin_ mma s = fmap (fmap (joinGroup s)) $ joinReader mma s
+>         joinReader = join
+>         joinGroup s ((x,s1),s2) = (x, s2 <> inv s <> s1)
+
+-}


### PR DESCRIPTION
This refactoring was done as a part of an attempt to extensively use `GND`/`DerivingVia` for defining `FMonad` instances. The attempt didn't go well, but I'll keep this as a PR for record.