### PR TITLE
Make "state fmonad" family explicit

### DIFF
--- a/functor-monad/src/FMonad/State/Day.hs
+++ b/functor-monad/src/FMonad/State/Day.hs
@@ -4,16 +4,21 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE DeriveFunctor #-}
 
 module FMonad.State.Day
-  (StateT, State,
+  (StateT(..),
    flift,
    toOuter, fromOuter, toInner, fromInner,
-   generalize) where
+   
+   State, state, state_, get, put,
+   runState
+) where
 
 import Control.Monad.Trans.Identity
 import Data.Functor.Day ( Day(..), day )
 import Data.Functor.Day.Curried ( Curried(Curried) )
+import Data.Functor.Day.Comonoid
 
 import FMonad
 import FMonad.Adjoint
@@ -23,22 +28,53 @@ import qualified FMonad.State.Simple.Inner as Simple.Inner
 import qualified FMonad.State.Simple.Outer as Simple.Outer
 
 import Data.Functor.Day.Extra
+import Data.Coerce (coerce)
+import Data.Functor.Identity
+import Data.Function ((&))
 
-type StateT s = AdjointT (Day s) (Curried s)
-type State s = StateT s IdentityT
+newtype StateT s mm x a = StateT { runStateT :: forall r. s (a -> r) -> mm (Day s x) r }
+   deriving stock Functor
+   deriving (FFunctor, FMonad) via (AdjointT (Day s) (Curried s) mm)
+
+toAdjointT :: StateT s mm x ~> AdjointT (Day s) (Curried s) mm x
+toAdjointT = coerce
+
+fromAdjointT :: AdjointT (Day s) (Curried s) mm x ~> StateT s mm x
+fromAdjointT = coerce
 
 flift :: (Functor s, FStrong mm, Functor x)
   => mm x ~> StateT s mm x
-flift mm = AdjointT $ Curried \sf -> fstrength' (day sf mm)
+flift mm = StateT $ \sf -> fstrength' (day sf mm)
 
 toOuter :: (Functor x, FFunctor mm) => StateT ((,) s0) mm x ~> Simple.Outer.StateT s0 mm x
-toOuter = AdjointT . ffmap (ffmap dayToEnv) . curriedToReader . runAdjointT
+toOuter = Simple.Outer.fromAdjointT . AdjointT . ffmap (ffmap dayToEnv) . curriedToReader . runAdjointT . toAdjointT
 
 fromOuter :: (Functor x, FFunctor mm) => Simple.Outer.StateT s0 mm x ~> StateT ((,) s0) mm x
-fromOuter = AdjointT . ffmap (ffmap envToDay) . readerToCurried . runAdjointT
+fromOuter = fromAdjointT . AdjointT . ffmap (ffmap envToDay) . readerToCurried . runAdjointT . Simple.Outer.toAdjointT
 
 toInner :: (Functor x, FFunctor mm) => StateT ((->) s1) mm x ~> Simple.Inner.StateT s1 mm x
-toInner = AdjointT . ffmap (ffmap dayToTraced) . curriedToWriter . runAdjointT
+toInner = Simple.Inner.fromAdjointT . AdjointT . ffmap (ffmap dayToTraced) . curriedToWriter . runAdjointT . toAdjointT
 
 fromInner :: (Functor x, FFunctor mm) => Simple.Inner.StateT s1 mm x ~> StateT ((->) s1) mm x
-fromInner = AdjointT . ffmap (ffmap tracedToDay) . writerToCurried . runAdjointT
+fromInner = fromAdjointT . AdjointT . ffmap (ffmap tracedToDay) . writerToCurried . runAdjointT . Simple.Inner.toAdjointT
+
+type State s = StateT s IdentityT
+
+state :: (FMonad mm)
+  => (forall r. s (a -> r) -> Day s x r)
+  -> StateT s mm x a
+state f = StateT $ \sar -> fpure (f sar)
+
+state_ :: (Functor s, FMonad mm)
+  => (forall b. s b -> (s b, x a))
+  -> StateT s mm x a
+state_ f = state (uncurry day . f)
+
+get :: (Comonoid s, FMonad mm) => StateT s mm s ()
+get = state (fmap ($ ()) . coapply)
+
+put :: (Comonad s, FMonad mm) => s a -> StateT s mm Identity a
+put sa = state (\sar -> Day sa (Identity (extract sar)) (&))
+
+runState :: State s x a -> s (a -> r) -> Day s x r
+runState sx = runIdentityT . runStateT sx

--- a/functor-monad/src/FMonad/State/Lan.hs
+++ b/functor-monad/src/FMonad/State/Lan.hs
@@ -2,8 +2,18 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE DerivingVia #-}
 module FMonad.State.Lan
-  (StateT, State, toInner, fromInner, generalize) where
+  (StateT(..),
+   fromAdjointT,
+   toAdjointT,
+   toInner, fromInner,
+   
+   State,
+   state, runState
+  ) where
 
 import Control.Monad.Trans.Identity
 import Data.Functor.Kan.Lan
@@ -15,18 +25,40 @@ import FMonad.Adjoint
 import Data.Tuple (swap)
 import Control.Monad.Trans.Writer (WriterT(..))
 import Control.Comonad.Traced (TracedT(..))
+import Data.Coerce (coerce)
 
-type StateT s = AdjointT (Lan s) (Precompose s)
-type State s = StateT s IdentityT
+-- type StateT s = AdjointT (Lan s) (Precompose s)
+newtype StateT s mm x a = StateT { runStateT :: mm (Lan s x) (s a) }
+  deriving (FFunctor, FMonad) via (AdjointT (Lan s) (Precompose s) mm)
+
+deriving
+  stock instance (FFunctor mm, Functor s) => Functor (StateT s mm x)
+
+toAdjointT :: StateT s mm x ~> AdjointT (Lan s) (Precompose s) mm x
+toAdjointT = coerce
+
+fromAdjointT :: AdjointT (Lan s) (Precompose s) mm x ~> StateT s mm x
+fromAdjointT = coerce
 
 toInner :: (Functor x, FFunctor mm) => StateT ((,) s1) mm x ~> Simple.Inner.StateT s1 mm x
-toInner = AdjointT . ffmap (ffmap lanToTraced) . (WriterT . fmap swap . getPrecompose) . runAdjointT
+toInner = Simple.Inner.fromAdjointT . AdjointT . ffmap (ffmap lanToTraced) . (WriterT . fmap swap . getPrecompose) . runAdjointT . toAdjointT
 
 fromInner :: (Functor x, FFunctor mm) => Simple.Inner.StateT s1 mm x ~> StateT ((,) s1) mm x
-fromInner = AdjointT . ffmap (ffmap tracedToLan) . (Precompose . fmap swap . runWriterT) . runAdjointT
+fromInner = fromAdjointT . AdjointT . ffmap (ffmap tracedToLan) . (Precompose . fmap swap . runWriterT) . runAdjointT . Simple.Inner.toAdjointT
 
 lanToTraced :: Functor f => Lan ((,) s1) f ~> TracedT s1 f
 lanToTraced (Lan sr_a fr) = TracedT $ fmap (\r s -> sr_a (s,r)) fr
 
 tracedToLan :: TracedT s1 f ~> Lan ((,) s1) f
 tracedToLan (TracedT fsa) = Lan (\(s1,sa) -> sa s1) fsa
+
+-- * Pure state
+
+type State s = StateT s IdentityT
+
+state :: (Functor s, FMonad mm, Functor x)
+  => (s b -> s a) -> x b -> StateT s mm x a
+state f xb = StateT $ fpure (Lan f xb)
+
+runState :: State s x a -> Lan s x (s a)
+runState = runIdentityT . runStateT

--- a/functor-monad/src/FMonad/State/Ran.hs
+++ b/functor-monad/src/FMonad/State/Ran.hs
@@ -3,29 +3,66 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeOperators #-}
 module FMonad.State.Ran
-  (StateT, State, toInner, fromInner, generalize) where
+  (StateT(..),
+  toInner, fromInner,
+  
+  State, state, state_, get, put,
+  runState
+  ) where
 
 import Control.Monad.Trans.Identity
 import Data.Functor.Kan.Ran
 import Data.Functor.Precompose
-import qualified FMonad.State.Simple.Inner as Simple.Inner
-
+import Data.Coerce (coerce)
+import Control.Comonad (Comonad(..))
+import Data.Functor.Identity
 import FMonad
 import FMonad.Adjoint
 import Control.Monad.Trans.Writer (WriterT(..))
 import Control.Comonad.Traced (TracedT(..))
 
-type StateT s = AdjointT (Precompose s) (Ran s)
-type State s = StateT s IdentityT
+import qualified FMonad.State.Simple.Inner as Simple.Inner
+
+-- type StateT s = AdjointT (Precompose s) (Ran s)
+newtype StateT s mm x a = StateT { runStateT :: forall r. (a -> s r) -> mm (Precompose s x) r }
+
+fromAdjointT :: AdjointT (Precompose s) (Ran s) mm x ~> StateT s mm x
+fromAdjointT = coerce
+
+toAdjointT :: StateT s mm x ~> AdjointT (Precompose s) (Ran s) mm x
+toAdjointT = coerce
 
 toInner :: (Functor x, FFunctor mm) => StateT ((->) s1) mm x ~> Simple.Inner.StateT s1 mm x
-toInner = AdjointT . ffmap (ffmap (TracedT . getPrecompose)) . ranToWriter . runAdjointT
+toInner = Simple.Inner.fromAdjointT . AdjointT . ffmap (ffmap (TracedT . getPrecompose)) . ranToWriter . runAdjointT . toAdjointT
 
 fromInner :: (Functor x, FFunctor mm) => Simple.Inner.StateT s1 mm x ~> StateT ((->) s1) mm x
-fromInner = AdjointT . ffmap (ffmap (Precompose . runTracedT)) . writerToRan . runAdjointT
+fromInner = fromAdjointT . AdjointT . ffmap (ffmap (Precompose . runTracedT)) . writerToRan . runAdjointT . Simple.Inner.toAdjointT
 
 ranToWriter :: Functor f => Ran ((->) s1) f ~> WriterT s1 f
 ranToWriter (Ran ran) = WriterT $ ran (,)
 
 writerToRan :: Functor f => WriterT s1 f ~> Ran ((->) s1) f
 writerToRan (WriterT f_as) = Ran $ \k -> fmap (uncurry k) f_as
+
+-- * Pure state
+
+type State s = StateT s IdentityT
+
+state :: (Functor s, Functor x, FMonad mm)
+  => (forall r. (a -> s r) -> x (s r))
+  -> StateT s mm x a
+state f = StateT $ \k -> fpure (Precompose (f k))
+
+state_ :: (Functor s, Functor x, FMonad mm)
+  => (forall r. s r -> x (s r))
+  -> StateT s mm x ()
+state_ f = state (\k -> f (k ()))
+
+get :: (Comonad s, FMonad mm) => StateT s mm s ()
+get = state_ duplicate
+
+put :: (Comonad s, FMonad mm) => s a -> StateT s mm Identity a
+put sa = state (\k -> Identity (extract . k <$> sa))
+
+runState :: State s x a -> (a -> s r) -> x (s r)
+runState sm k = getPrecompose $ runIdentityT $ runStateT sm k

--- a/functor-monad/src/FMonad/State/Simple/Inner.hs
+++ b/functor-monad/src/FMonad/State/Simple/Inner.hs
@@ -5,10 +5,19 @@
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE StandaloneDeriving #-}
 
 module FMonad.State.Simple.Inner
-  (StateT, State, generalize,
-   state, runState, flift) where
+  (StateT(..),
+   flift,
+   toAdjointT,
+   fromAdjointT,
+   
+   State,
+   state,
+   runState
+) where
 
 import Control.Monad.Trans.Identity ( IdentityT(..) )
 import Control.Comonad.Trans.Traced ( TracedT(..) )
@@ -17,19 +26,29 @@ import Data.Functor.Day (Day(..), swapped)
 import Data.Functor.Day.Extra (dayToTraced)
 import Data.Coerce (coerce)
 
-import FFunctor ( FFunctor(..), type (~>) )
+import FMonad
 import FMonad.Adjoint
 import FStrong
 
-type StateT s1 = AdjointT (TracedT s1) (WriterT s1)
+newtype StateT s1 mm x a = StateT { runStateT :: mm (TracedT s1 x) (a, s1) }
+   deriving (FFunctor, FMonad) via (AdjointT (TracedT s1) (WriterT s1) mm)
 type State s1 = StateT s1 IdentityT
+
+deriving
+  stock instance (FFunctor mm, Functor x) => Functor (StateT s1 mm x)
+
+toAdjointT :: StateT s1 mm x ~> AdjointT (TracedT s1) (WriterT s1) mm x
+toAdjointT = coerce
+
+fromAdjointT :: AdjointT (TracedT s1) (WriterT s1) mm x ~> StateT s1 mm x
+fromAdjointT = coerce
 
 flift :: (FStrong mm, Functor x)
   => mm x ~> StateT s1 mm x
-flift mm = AdjointT $ WriterT $ ffmap (dayToTraced . swapped) (fstrength (Day mm id (,)))
+flift mm = fromAdjointT $ AdjointT $ WriterT $ ffmap (dayToTraced . swapped) (fstrength (Day mm id (,)))
 
-state :: forall s1 x a. Functor x => x (s1 -> (a, s1)) -> State s1 x a
-state = coerce
+state :: forall s1 x mm a. (Functor x, FMonad mm) => x (s1 -> (a, s1)) -> StateT s1 mm x a
+state = StateT . fpure . TracedT
 
 runState :: State s1 x a -> x (s1 -> (a, s1))
 runState = coerce

--- a/functor-monad/src/FMonad/State/Simple/Outer.hs
+++ b/functor-monad/src/FMonad/State/Simple/Outer.hs
@@ -5,30 +5,47 @@
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE StandaloneDeriving #-}
 
 module FMonad.State.Simple.Outer
-  (StateT, State, generalize,
-   state, runState, flift) where
+  (StateT(..), flift, 
+   fromAdjointT, toAdjointT,
+
+   State,
+   state, runState, 
+  ) where
 
 import Control.Monad.Trans.Identity ( IdentityT(..) )
 import Control.Comonad.Trans.Env
 import Control.Monad.Trans.Reader
 import Data.Tuple (swap)
+import Data.Coerce (coerce)
 
 import FMonad
 import FMonad.Adjoint
 
-type StateT s0 = AdjointT (EnvT s0) (ReaderT s0)
+newtype StateT s0 mm x a = StateT { runStateT :: s0 -> mm (EnvT s0 x) a }
+   deriving (FFunctor, FMonad) via (AdjointT (EnvT s0) (ReaderT s0) mm)
 type State s0 = StateT s0 IdentityT
+
+deriving
+  stock instance (FFunctor mm, Functor x) => Functor (StateT s0 mm x)
+
+fromAdjointT :: AdjointT (EnvT s0) (ReaderT s0) mm x ~> StateT s0 mm x
+fromAdjointT =  coerce
+
+toAdjointT :: StateT s0 mm x ~> AdjointT (EnvT s0) (ReaderT s0) mm x
+toAdjointT = coerce
 
 flift :: (FFunctor mm, Functor x)
   => mm x ~> StateT s0 mm x
-flift mm = AdjointT $ ReaderT \s0 -> ffmap (EnvT s0) mm
+flift mm = StateT $ \s0 -> ffmap (EnvT s0) mm
 
-state :: forall s0 x a. (s0 -> (x a, s0)) -> State s0 x a
-state stateX = AdjointT $ ReaderT \s0 ->
-    case stateX s0 of
-        (x, s0') -> IdentityT (EnvT s0' x)
+state :: forall s0 x mm a. (FMonad mm, Functor x) => (s0 -> (x a, s0)) -> StateT s0 mm x a
+state stateX = StateT \s0 ->
+    let (x, s0') = stateX s0
+     in fpure (EnvT s0' x)
 
 runState :: forall s0 x a. State s0 x a -> s0 -> (x a, s0)
-runState stateX = swap . runEnvT . runIdentityT . runReaderT (runAdjointT stateX)
+runState stateX = swap . runEnvT . runIdentityT . runStateT stateX


### PR DESCRIPTION
Make every FMonad defined under modules `FMonad.State.**` a distinguished type, instead of a type synonym of `AdjointT`.